### PR TITLE
Bugfix / Update PyPi Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.2.2] - ?
+## [0.2.2] - TBD
+
+### Fixed
+- Updates PyPi version to latest (#161)
+
+## [0.2.1] - 2016-10-18
 
 ### Fixed
 - `AUTOENV_CUR_DIR` contains leading double quote (#150)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 
 setuptools.setup(
-    version='0.2.0',
+    version='0.2.2',
     name='autoenv',
     description='Directory-based environments.',
     author='Kenneth Reitz',


### PR DESCRIPTION
- Bump version to 0.2.2 in `setup.py` - fixes PR #161
- Correct `CHANGELOG.md` date and version for v0.2.1 release
- Add v0.2.2 to `CHANGELOG.md` - will need to be tagged and released if PR is approved