### PR TITLE
Fix infinite loop on OSX Catalina in activate.sh

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -32,6 +32,7 @@ ${_file}"
 				fi
 			fi
 			[ "$(\pwd -P)" = "${_mountpoint}" ] && \break
+      [ "$(\pwd -P)" = "/" ] && \break
 			\command -v chdir >/dev/null 2>&1 && \chdir "$(\pwd -P)/.." || builtin cd "$(pwd -P)/.."
 		done
 	)


### PR DESCRIPTION
Fixes https://github.com/inishchith/autoenv/issues/188

This implements @sennav and @meermanr's suggestion as a pull request.

Due to Catalina's new firmlinks, this fixes an infinite loop on OSX Catalina 10.15.

Manually running `source activate.sh` will enter the infinite loop condition. Manually running `source activate.sh` with the line change returns nearly immediately and enables autoenv.