### PR TITLE
Improve shell syntax in test suite

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -14,7 +14,7 @@ done
 
 MKTEMP=$(command -v mktemp)
 READLINK=$(command -v readlink)
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
 	for cmd in gmktemp greadlink; do
 		if ! has_cmd "$cmd"; then
 			echo ":: This test requires the ${cmd} executable."

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -30,14 +30,14 @@ shells='bash:bash --noprofile --norc|zsh:zsh|sh:dash' # Shells to test. Shells s
 
 # Global variables
 TMPDIR='' # Global so we can react when the script fails
-basedir=$("$READLINK" -f "$(dirname $0)") # So we can find our tests
-oldpwd="`pwd`" # So we can come back after testing
+basedir=$("$READLINK" -f "$(dirname "$0")") # So we can find our tests
+oldpwd="$(pwd)" # So we can come back after testing
 ZDOTDIR='/dev/null' # Don't use default ZSH files
 export ZDOTDIR
 
 # Discover tests
 tests=''
-for file in `find "${basedir}" -type f -name 'test_*.sh'`; do
+for file in $(find "${basedir}" -type f -name 'test_*.sh'); do
 	tests="${tests}|`basename \"$file\" .sh`"
 done
 tests="${tests#|}"
@@ -76,14 +76,14 @@ IFS='|'
 for shell in ${shells}; do
 	for current_test in ${tests}; do
 		# Prepare this test
-		printf %s ":: Running ${current_test} for `echo "${shell}" | cut -d':' -f1`..."
-		TMPDIR=$("$MKTEMP" -dp ${basedir} ${current_test}.XXXXXX)
+		printf %s ":: Running ${current_test} for $(echo "${shell}" | cut -d':' -f1)..."
+		TMPDIR=$("$MKTEMP" -dp "${basedir}" "${current_test}.XXXXXX")
 		AUTOENV_AUTH_FILE="${TMPDIR}/autoenv_authorized" # Don't use default auth file
 		export TMPDIR
 		export AUTOENV_AUTH_FILE
 		cd "${TMPDIR}"
 		# Run this test
-		eval `echo "$shell" | cut -d':' -f2` "${basedir}/$current_test.sh" > "${basedir}/lasttest.log" 2>&1
+		eval "$(echo "$shell" | cut -d':' -f2) ${basedir}/$current_test.sh" > "${basedir}/lasttest.log" 2>&1
 		# Tear this test down
 		echo "Success."
 		cd "${oldpwd}"


### PR DESCRIPTION
This fixes an issue in which the tests wouldn't run due to the use of a Bashism. It also fixes most miscellaneous quoting and command substitution issues